### PR TITLE
Controllo ordinamento h2

### DIFF
--- a/.github/workflows/format-validation.yml
+++ b/.github/workflows/format-validation.yml
@@ -1,0 +1,13 @@
+name: Validate Formatting
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check sort titles
+        run: grep -o '## .*' README.md | sort -c


### PR DESCRIPTION
### Descrizione

Poiché ci sono numerosi ruoli professionali da elencare, è importante avere una lista ben organizzata in ordine alfabetico. 
Pertanto, ho introdotto una funzionalità che verifica tutti gli header di secondo livello (H2) nel file readme, in cui sono elencati i ruoli professionali, e verifica se sono correttamente ordinati. In caso contrario, il test non avrà successo.

Ho fatto una PR di prova sul mio fork. Questa è la [PR](https://github.com/corradopetrelli/galactic-tech-job-roles-guide/pull/2) dove ho testato.

### Screenshot

#### Caso Test ✅ 
![image](https://github.com/GuidoPenta/galactic-tech-job-roles-guide/assets/36475130/913dd3b6-409f-46e2-949a-bafca2b94955)

#### Caso Test ❌ 
![image](https://github.com/GuidoPenta/galactic-tech-job-roles-guide/assets/36475130/0504fa30-6abf-412e-83a9-b51f42787153)
